### PR TITLE
PSR-7 stream support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ cs.check:
 
 stan:
 	PHP=81 make composer.update
-	docker exec 68publishers.file-storage.81 vendor/bin/phpstan analyse
+	docker exec 68publishers.file-storage.81 vendor/bin/phpstan analyse --memory-limit=-1
 
 coverage:
 	PHP=81 make composer.update

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
 	],
 	"require": {
 		"php": "^8.1",
-		"ext-json": "*",
 		"ext-fileinfo": "*",
+		"ext-json": "*",
 		"league/flysystem": "^3.12",
+		"psr/http-message": "^2.0",
 		"psr/log": "^1.1 || ^2.0 || ^3.0"
 	},
 	"require-dev": {
@@ -21,6 +22,7 @@
 		"doctrine/dbal": "^2.13.1 || ^3.1.1",
 		"fig/log-test": "^1.1",
 		"friendsofphp/php-cs-fixer": "^3.13",
+		"guzzlehttp/psr7": "^2.7",
 		"kubawerlos/php-cs-fixer-custom-fixers": "^3.13",
 		"latte/latte": "^3.0",
 		"league/flysystem-memory": "^3.10",

--- a/src/Bridge/Nette/DI/FileStorageExtension.php
+++ b/src/Bridge/Nette/DI/FileStorageExtension.php
@@ -69,7 +69,7 @@ final class FileStorageExtension extends CompilerExtension implements FileStorag
                         'adapter' => Expect::anyOf(Expect::string(), Expect::type(Statement::class))->required()->before(static function ($factory) {
                             return $factory instanceof Statement ? $factory : new Statement($factory);
                         }),
-                        'config' => Expect::array([
+                        'config' => Expect::array([ # @phpstan-ignore-line false positive `Call to an undefined method Nette\Schema\Elements\Structure|Nette\Schema\Elements\Type::mergeDefaults().`
                             FlysystemConfig::OPTION_VISIBILITY => Visibility::PUBLIC,
                             FlysystemConfig::OPTION_DIRECTORY_VISIBILITY => Visibility::PUBLIC,
                         ])->mergeDefaults(),

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SixtyEightPublishers\FileStorage;
 
 use League\Flysystem\FilesystemOperator;
+use Psr\Http\Message\StreamInterface;
 use SixtyEightPublishers\FileStorage\Config\ConfigInterface;
 use SixtyEightPublishers\FileStorage\Exception\PathInfoException;
 use SixtyEightPublishers\FileStorage\Helper\Path;
@@ -79,5 +80,10 @@ class FileStorage implements FileStorageInterface
     public function createResourceFromFile(PathInfoInterface $pathInfo, string $filename): ResourceInterface
     {
         return $this->resourceFactory->createResourceFromFile($pathInfo, $filename);
+    }
+
+    public function createResourceFromPsrStream(PathInfoInterface $pathInfo, StreamInterface $stream): ResourceInterface
+    {
+        return $this->resourceFactory->createResourceFromPsrStream($pathInfo, $stream);
     }
 }

--- a/src/Resource/ResourceFactory.php
+++ b/src/Resource/ResourceFactory.php
@@ -187,6 +187,7 @@ final class ResourceFactory implements ResourceFactoryInterface
                 'http' => [
                     'method' => 'GET',
                     'protocol_version' => 1.1,
+                    'follow_location' => true,
                     'header' => "Accept-language: en\r\n" . "User-Agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36\r\n",
                 ],
             ],

--- a/src/Resource/ResourceFactoryInterface.php
+++ b/src/Resource/ResourceFactoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SixtyEightPublishers\FileStorage\Resource;
 
+use Psr\Http\Message\StreamInterface;
 use SixtyEightPublishers\FileStorage\Exception\FileNotFoundException;
 use SixtyEightPublishers\FileStorage\Exception\FilesystemException;
 use SixtyEightPublishers\FileStorage\PathInfoInterface;
@@ -21,4 +22,10 @@ interface ResourceFactoryInterface
      * @throws FilesystemException
      */
     public function createResourceFromFile(PathInfoInterface $pathInfo, string $filename): ResourceInterface;
+
+    /**
+     * @throws FileNotFoundException
+     * @throws FilesystemException
+     */
+    public function createResourceFromPsrStream(PathInfoInterface $pathInfo, StreamInterface $stream): ResourceInterface;
 }

--- a/tests/FileStorageTest.phpt
+++ b/tests/FileStorageTest.phpt
@@ -6,6 +6,7 @@ namespace SixtyEightPublishers\FileStorage\Tests;
 
 use League\Flysystem\FilesystemOperator;
 use Mockery;
+use Psr\Http\Message\StreamInterface;
 use SixtyEightPublishers\FileStorage\Config\ConfigInterface;
 use SixtyEightPublishers\FileStorage\FileStorage;
 use SixtyEightPublishers\FileStorage\LinkGenerator\LinkGeneratorInterface;
@@ -153,6 +154,23 @@ final class FileStorageTest extends TestCase
             ->andReturns($resource);
 
         Assert::same($resource, $storage->createResourceFromFile($pathInfo, 'var/www/file.json'));
+    }
+
+    public function testResourceFromPsrStreamShouldBeCreated(): void
+    {
+        $resourceFactory = Mockery::mock(ResourceFactoryInterface::class);
+        $resource = Mockery::mock(ResourceInterface::class);
+        $stream = Mockery::mock(StreamInterface::class);
+
+        $storage = $this->createFileStorage(resourceFactory: $resourceFactory);
+        $pathInfo = $storage->createPathInfo('var/www/file.json');
+
+        $resourceFactory->shouldReceive('createResourceFromPsrStream')
+            ->once()
+            ->with($pathInfo, $stream)
+            ->andReturns($resource);
+
+        Assert::same($resource, $storage->createResourceFromPsrStream($pathInfo, $stream));
     }
 
     protected function tearDown(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating resources directly from PSR-7 streams.
  - Introduced a new method for resource creation from streams in the interface and main storage class.

- **Bug Fixes**
  - Improved handling of static analysis warnings without affecting functionality.

- **Tests**
  - Added comprehensive tests for resource creation from PSR-7 streams, including both file-based and in-memory streams.

- **Chores**
  - Updated dependencies to include PSR-7 support and related packages.
  - Adjusted static analysis configuration for improved compatibility.
  - Removed memory limits for static analysis to enhance performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->